### PR TITLE
projects.md: add notes about runc and containerd

### DIFF
--- a/docs/projects.md
+++ b/docs/projects.md
@@ -25,3 +25,5 @@ https://api.github.com/repos/{{ project }}
 {% endfor %}
 </div>
 </div>
+
+Note: [runc](https://github.com/opencontainers/runc) is owned by [Open Container Initiative (OCI)](https://www.opencontainers.org), and [containerd](https://github.com/containerd/containerd) is owned by [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io).


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>