### PR TITLE
projects: add libentitlement, moby-registry; update notary

### DIFF
--- a/docs/_data/projects.yml
+++ b/docs/_data/projects.yml
@@ -1,7 +1,7 @@
 - docker/infrakit
 - containerd/containerd
 - opencontainers/runc
-- docker/notary
+- theupdateframework/notary
 - linuxkit/linuxkit
 - moby/datakit
 - moby/vpnkit
@@ -11,3 +11,5 @@
 - moby/hyperkit
 - moby/moby
 - moby/tool
+- moby/libentitlement
+- docker/distribution

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -34,4 +34,4 @@ https://api.github.com/repos/{{ project }}
 </div>
 </div>
 
-_Note: [runc](https://github.com/opencontainers/runc) is owned by [Open Container Initiative (OCI)](https://www.opencontainers.org), and [containerd](https://github.com/containerd/containerd) is owned by [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io)._
+_Note: [runc](https://github.com/opencontainers/runc) is owned by [Open Container Initiative (OCI)](https://www.opencontainers.org). [containerd](https://github.com/containerd/containerd) and [Notary](https://github.com/theupdateframework/notary) are owned by [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io)._


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

Added:
- libentitlement: already added to Moby github org https://github.com/moby/libentitlement
- moby-registry (still docker/distribution): discussed in https://github.com/moby/moby/issues/35115

Updated:
- notary: now CNCF project but still part of the Moby Project (Question: is TUF part of the Moby Project as well?)


@moby/mobywebsite @crosbymichael @tiborvass