### PR TITLE
Add subsection on the TSC

### DIFF
--- a/docs/projects.md
+++ b/docs/projects.md
@@ -9,17 +9,30 @@ Moby is an open-source project, created by Docker, to enable and accelerate soft
 
 ![Moby projects](/images/dockercon-2017-eu.000.jpeg)
 
-The projects themselves provide a "Lego set" of toolkit components, the framework for assembling them into custom container-based systems, and a place for all container enthusiasts and professionals to experiment and exchange ideas.
+The projects themselves provide a "Lego set" of toolkit components, the framework for assembling them into custom container-based systems, and a place for all container enthusiasts and professionals to experiment and exchange ideas. There is a Technical Steering committee, elected by the projects, to help with project governance.
 
-Moby Project also hosts Special Interest Groups (SIG) for discussing subtopics among interested contributors. SIGs typically meet every week and post their meeting minutes and video of the meetings online.  If you're interested in starting a SIG, please begin a discussion on the [forum](https://forums.mobyproject.org).
 <br />
 
-### List of Moby Special Interest Groups
+### Technical Steering Committee
+
+The Technical Steering Committee acts as an escalation point for conflicts within projects, encourages cross-project communication and coordination, as well as helping with project governance. The TSC is not involved in the day-to-day activities of the projects but can resolve technical disputes when an issue has been escalated to the committee.  
+
+Seats on the committee are allocated by election and seats are held for a fixed term. You can read more about the Technical Steering Committee, including the list of [current members](https://github.com/moby/tsc/blob/master/MEMBERS.md), over on the [TSC repository](https://github.com/moby/tsc).
+
+<br />
+
+### Moby Special Interest Groups
+
+Moby Project also hosts Special Interest Groups (SIG) for discussing subtopics among interested contributors. SIGs typically meet every week and post their meeting minutes and video of the meetings online.  If you're interested in starting a SIG, please begin a discussion on the [forum](https://forums.mobyproject.org).
+
+**Current SIGs**
 
 | Name | Leads | Agenda | Forum | Meetings |
 |------|-------|--------|-------|----------|
 | [LinuxKit Security](https://github.com/linuxkit/linuxkit/tree/master/sigs/security) | [@riyazdf](https://github.com/riyazdf) Riyaz Faizullabhoy | [Agenda and Meeting Notes](https://github.com/linuxkit/linuxkit/tree/master/reports/sig-security) | [Forum](https://forums.mobyproject.org/c/sig/linuxkit-security) | [Every other Wednesday at 9:00 AM PST](https://docker.zoom.us/j/779801882) |
 | [Orchestration Security](https://github.com/docker/swarmkit/tree/master/sigs/orchestration-security) | [@diogomonica](https://github.com/diogomonica) Diogo Monica | [Agenda and Meeting Notes](https://docs.google.com/document/d/1co6Jv9Mq8jeToK-sYNNXwUQiPWcDCvlNJ5bozAOfriE/edit) | [Forum](https://forums.mobyproject.org/c/sig/orchestration-security) | [Every other Tuesday at 3:00 PM PST](https://docker.zoom.us/j/417366441) |
+
+<br />
 
 ### List of Moby Projects
 


### PR DESCRIPTION
Also restructure some other content for easier reading.

I avoided putting specific details of the TSC on this page since the repo should always have the canonical version.  So if the doc itself undergoes revisions, we won't have out-of-sync content.
