### PR TITLE
Fix the link to Moby project on Github

### DIFF
--- a/docs/_includes/links.html
+++ b/docs/_includes/links.html
@@ -1,6 +1,6 @@
 <ul class="navbar-nav mr-auto">
 <li class="nav-item nav-icon">
-	<a  data-toggle="tooltip"  data-toggle="tooltip" data-placement="bottom" title="check us out on github" href="https://github.com/moby/moby/blob/moby/README.md">
+	<a  data-toggle="tooltip"  data-toggle="tooltip" data-placement="bottom" title="check us out on github" href="https://github.com/moby/moby/blob/master/README.md">
 	<i class="fa fa-github" aria-hidden="true"></i></a>
 </li>
 <li><a class="nav-item nav-icon"> 


### PR DESCRIPTION
The Moby project on Github does not have the moby branch.
Suggest to use the master branch instead.
See:
https://github.com/moby/moby/blob/master/README.md